### PR TITLE
Fix missing pro_micro.h

### DIFF
--- a/lily58/rev1/matrix.c
+++ b/lily58/rev1/matrix.c
@@ -30,7 +30,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "util.h"
 #include "matrix.h"
 #include "split_util.h"
-#include "pro_micro.h"
+#include "quantum.h"
 
 #ifdef USE_MATRIX_I2C
 #  include "i2c.h"
@@ -96,13 +96,15 @@ uint8_t matrix_cols(void)
 void matrix_init(void)
 {
     split_keyboard_setup();
+
     // initialize row and col
     unselect_rows();
     init_cols();
 
-    TX_RX_LED_INIT;
-    TXLED0;
-    RXLED0;
+    setPinOutput(B0);
+    setPinOutput(D5);
+    writePinHigh(B0);
+    writePinHigh(D5);
 
     // initialize matrix state: all keys off
     for (uint8_t i=0; i < MATRIX_ROWS; i++) {
@@ -187,10 +189,10 @@ int serial_transaction(int master_changed) {
     int ret=serial_update_buffers();
 #endif
     if (ret ) {
-        if(ret==2) RXLED1;
+        if(ret==2) writePinLow(B0);
         return 1;
     }
-    RXLED0;
+    writePinHigh(B0);
     memcpy(&matrix[slaveOffset],
         (void *)serial_slave_buffer, SERIAL_SLAVE_BUFFER_LENGTH);
     return 0;
@@ -239,7 +241,7 @@ uint8_t matrix_master_scan(void) {
     if( serial_transaction(mchanged) ) {
 #endif
         // turn on the indicator led when halves are disconnected
-        TXLED1;
+        writePinLow(D5);
 
         error_count++;
 
@@ -252,7 +254,7 @@ uint8_t matrix_master_scan(void) {
         }
     } else {
         // turn off the indicator led on no error
-        TXLED0;
+        writePinHigh(D5);
         error_count = 0;
     }
     matrix_scan_quantum();


### PR DESCRIPTION
Upstream repository has removed `pro_micro.h` (see https://github.com/qmk/qmk_firmware/pull/8374) breaking compilation of this custom code.  Updating the `matrix.c` file resolves allows the firmware to compile.  I have not yet tested for functionality.